### PR TITLE
Use --spaces=1 for aasvg and protocol

### DIFF
--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -466,7 +466,7 @@ COLORS
             result1, err, _s = Open3.capture3("goat #{file.path}", stdin_data: result);
             dont_clean = true
           elsif t == "protocol-aasvg"
-            result1, err, _s = Open3.capture3("aasvg", stdin_data: result);
+            result1, err, _s = Open3.capture3("aasvg --spaces=1", stdin_data: result);
             dont_clean = true
           else
             result1 = nil


### PR DESCRIPTION
Protocol is weird in that it produces a long line of "text" that aasvg
will put into the one element.  If you tell aasvg to break at the first
space (as opposed to the second), then it will place each letter more
precisely.  The cost is less control over inter-word spacing inside the
diagram (but better control over individual words).

There is a --stretch feature, but that uses SVG attributes that RFC 7996 won't allow, so ლ(╹◡╹ლ)