### PR TITLE
Swap the order of `<xref...><iref...>`

### DIFF
--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -1390,9 +1390,9 @@ COLORS
         end
         iref ||= "<iref#{html_attributes(item: item, subitem: subitem)}/>"
         if target
-          "<xref#{html_attributes(target: target, format: "none")}>#{value}</xref>#{iref}"
+          "#{iref}<xref#{html_attributes(target: target, format: "none")}>#{value}</xref>"
         else
-          "#{value}#{iref}"
+          "#{iref}#{value}"
         end
       end
 


### PR DESCRIPTION
The automated linking of terms currently produces an `<xref>` element immediately followed by an empty `<iref>` element.  This is basically fine, except for a few things:

1. The anchor that is created appears at the end of the text string, which means that following a link from the index can sometimes miss the actual target if the text wraps across two lines.
2. An ordering of iref then xref enables different styling of the xref in CSS.  This might be used to make links generated in this fashion appear less obvious.  Some readers have reported that they find the obvious links (with a change of colour) distracting.

These both suggest that `<iref...><xref...>` is a better ordering. Implement that.