### PR TITLE
kramdown-rfc --help synopsis should indicate support for reading from stdin

### DIFF
--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -490,7 +490,7 @@ require 'ostruct'
 $options ||= OpenStruct.new
 op = OptionParser.new do |opts|
   opts.banner = <<BANNER
-Usage: kramdown-rfc2629 [options] file.md|file.mkd > file.xml
+Usage: kramdown-rfc2629 [options] [MARKDOWNFILE] > file.xml
 Version: #{KDRFC_VERSION}
 BANNER
   opts.on("-V", "--version", "Show version and exit") do |v|


### PR DESCRIPTION
kramdown-rfc uses [Ruby's ARGF](https://docs.ruby-lang.org/en/master/ARGF.html), which accepts data from stdin if no argument is supplied.

But the current synopsis seems to expect a filename as an argument.

The synopsis also appears to make some sort of arbitrary distinction between a .md and a .mkd suffix, and adds a pipe metacharacter.

Simplify all of this by indicating that the filename is optional (enclosing it in brackets) and renaming it from file.md|file.mkd to MARKDOWNFILE.