### PR TITLE
Switch BCP 14 boilerplate from nbsp to regular space

### DIFF
--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -82,7 +82,7 @@ RFC8174ise
 The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL
 NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED",
 "MAY", and "OPTIONAL" in this document are to be interpreted as
-described in BCP 14 {{!RFC2119}} {{!RFC8174}} when, and only when, they
+described in BCP 14 {{!RFC2119}} {{!RFC8174}} when, and only when, they
 appear in all capitals, as shown here.
 RFC8174
     if $2


### PR DESCRIPTION
This matches what the RFC Editor is doing now, found out about this during AUTH48 for 9484