### PR TITLE
kramdown-rfc-extract-sourcecode: Provide better names to the extracted files

### DIFF
--- a/bin/kramdown-rfc-extract-sourcecode
+++ b/bin/kramdown-rfc-extract-sourcecode
@@ -8,7 +8,8 @@ require_relative '../lib/kramdown-rfc/rexml-all-text.rb'
 
 def clean(s)
   s.gsub!(/\//, ":")
-  s.gsub!(/[^:\w]/, "_")        # handles leading dot, too --   s.gsub!(/\A([.]+)/) {"_" * $1.size } otherwise
+  s.gsub!(/\A([-.]+)/) {"_" * $1.size }
+  s.gsub!(/[^-.:\w]/, "_")
   s
 end
 
@@ -53,7 +54,10 @@ REXML::XPath.each(d.root, "//sourcecode|//artwork") do |x|
   if ty = x[:type]
     ty = clean(ty)
     name = x[:name]
-    name = gensym.succ! if !name || name.empty?
+    if !name || name.empty?
+      name = gensym.succ!.dup
+      name = "#{name}.#{ty}" unless ty.empty?
+    end
     name = clean(name)
     if taken[ty][name]
       unless warned[ty][name]

--- a/kramdown-rfc.gemspec
+++ b/kramdown-rfc.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc'
-  s.version = '1.6.43'
+  s.version = '1.7.1'
   s.summary = "Kramdown extension for generating RFCXML (RFC 799x)."
   s.description = %{An RFCXML (RFC 799x) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}

--- a/kramdown-rfc2629.gemspec
+++ b/kramdown-rfc2629.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc2629'
-  s.version = '1.6.43'
+  s.version = '1.7.1'
   s.summary = "Kramdown extension for generating RFCXML (RFC 799x)."
   s.description = %{An RFCXML (RFC 799x) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}


### PR DESCRIPTION
* sourcecode-name values are less heavily mangled; the characters "-" and "." are now allowed (except at the start) and no longer converted into underscores.

* unnamed files now have their sourcecode type attached (e.g., if the sourcecode type is abnf, unnamed-123 ➔ unnamed-123.abnf)

This update will, unfortunately, be a flag day for those using this feature from Makefiles or includes in the markdown.

close #206