### PR TITLE
Remove the REXML pin

### DIFF
--- a/kramdown-rfc.gemspec
+++ b/kramdown-rfc.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc'
-  s.version = '1.7.15'
+  s.version = '1.7.16'
   s.summary = "Kramdown extension for generating RFCXML (RFC 799x)."
   s.description = %{An RFCXML (RFC 799x) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}

--- a/kramdown-rfc2629.gemspec
+++ b/kramdown-rfc2629.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc2629'
-  s.version = '1.7.15'
+  s.version = '1.7.16'
   s.summary = "Kramdown extension for generating RFCXML (RFC 799x)."
   s.description = %{An RFCXML (RFC 799x) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}
@@ -14,7 +14,6 @@ spec = Gem::Specification.new do |s|
   s.add_dependency('net-http-persistent', '~> 4.0')
   s.add_dependency('differ', '~> 0.1')
   s.add_dependency('base64', '>= 0.1')
-  s.add_dependency('rexml', '<= 3.2.6') # emergency fix; newer REXML is no longer pure ruby (requires strscan)
   s.files = Dir['lib/**/*.rb'] + %w(README.md LICENSE kramdown-rfc2629.gemspec bin/kdrfc bin/kramdown-rfc bin/kramdown-rfc2629 bin/doilit bin/echars bin/kramdown-rfc-extract-markdown bin/kramdown-rfc-extract-sourcecode bin/kramdown-rfc-lsr data/kramdown-rfc2629.erb data/encoding-fallbacks.txt data/math.json bin/kramdown-rfc-cache-subseries-bibxml bin/kramdown-rfc-autolink-iref-cleanup bin/de-gfm bin/kramdown-rfc-clean-svg-ids)
   s.require_path = 'lib'
   s.executables = ['kramdown-rfc', 'kramdown-rfc2629', 'doilit', 'echars',


### PR DESCRIPTION
"Fixes" #232
REXML 3.3.0 removed the pin on strscan, so this fix is no longer necessary.
https://github.com/ruby/rexml/commit/f1df7d13b3e57a5e059273d2f0870163c08d7420#diff-75d0a867bbfd5e375164c17cf7a9df96761fb050e7308f3918ad6fe1fe12d27dL58

The pin prevents us from upgrading Nixos' kramdown-rfc2629.