### PR TITLE
Prototype for generating lists of figures and tables

### DIFF
--- a/bin/kramdown-rfc-extract-figures-tables
+++ b/bin/kramdown-rfc-extract-figures-tables
@@ -6,7 +6,7 @@ require 'optparse'
 PROGNAME = "kramdown-rfc-extract-figures-tables"
 
 target = :section
-targets = [:note, :section]
+targets = [:section, :note]
 require 'optparse'
 begin
   op = OptionParser.new do |opts|

--- a/bin/kramdown-rfc-extract-figures-tables
+++ b/bin/kramdown-rfc-extract-figures-tables
@@ -48,11 +48,11 @@ REXML::XPath.each(d.root, %{//figure|//*[name()="table" or name()="texttable"]})
     # p [gi, out.last]
   end
   gi1 = if gi == "texttable"; "table" else gi end
-  if out == []         # ignore nameless fig, synth name for nameless table
-    if gi == "figure"
-      next                      # What if anchor but no title?
-    end
-    out = ["Table #{lists["table"].size + 1}"]
+  if out == []         # nameless
+    # nameless, anchorless fig doesn't get a number; ignore
+    next if gi == "figure" && !ref
+    # Synthesize name (if not redundant)
+    out = ["#{gi1.capitalize} #{lists[gi1].size + 1}"] if !ref
   end
   # p [gi, out]
   lists[gi1] << [ref, out.join(" ")]

--- a/bin/kramdown-rfc-extract-figures-tables
+++ b/bin/kramdown-rfc-extract-figures-tables
@@ -3,7 +3,7 @@ require 'rexml/document'
 require 'yaml'
 require 'optparse'
 
-PROGNAME = "kramdown-rfc-extract-figures-tables"
+PROGNAME = $0 # "kramdown-rfc-extract-figures-tables"
 
 target = :section
 targets = [:section, :note]

--- a/bin/kramdown-rfc-extract-figures-tables
+++ b/bin/kramdown-rfc-extract-figures-tables
@@ -1,0 +1,79 @@
+#!/usr/bin/env ruby -KU
+require 'rexml/document'
+require 'yaml'
+require 'optparse'
+require 'pp'
+
+PROGNAME = "kramdown-rfc-extract-figures-tables"
+
+target = :section
+targets = [:note, :section]
+require 'optparse'
+begin
+  op = OptionParser.new do |opts|
+    opts.banner = "Usage: #{PROGNAME} [options] [-|document.xml]"
+    opts.on("-tFMT", "--to=FMT", targets, "Target format #{targets.map(&:to_s)}") do |v|
+      target = v
+    end
+  end
+  op.parse!
+rescue Exception => e
+  warn e
+  exit 1
+end
+
+class String
+  def spacify
+    gsub(/\s+/, " ")
+  end
+end
+
+lists = Hash.new { |h, k| h[k] = [] }
+d = REXML::Document.new(ARGF)
+unless d.root
+  warn "** #{PROGNAME}: Cannot parse input"
+  exit 1
+end
+REXML::XPath.each(d.root, %{//figure|//*[name()="table" or name()="texttable"]}) do |x|
+  gi = x.name
+  ref = x[:anchor]
+  # p [gi, ref]
+  out = []
+  REXML::XPath.each(x, "name") do |nm|
+    out << nm.children.map{|ch| ch.to_s}.join
+    # p [gi, out.last]
+  end
+  REXML::XPath.each(x, "@title") do |ttl|
+    out << ttl.to_s.spacify
+    # p [gi, out.last]
+  end
+  gi1 = if gi == "texttable"; "table" else gi end
+  if out == []         # ignore nameless fig, synth name for nameless table
+    if gi == "figure"
+      next                      # What if anchor but no title?
+    end
+    out = ["Table #{lists["table"].size + 1}"]
+  end
+  # p [gi, out]
+  lists[gi1] << [ref, out.join(" ")]
+end
+
+lists.each do |k, v|
+  title = "List of #{k.capitalize}s"
+  case target
+  when :note
+    puts
+    puts "--- note_#{title.gsub(" ", "_")}"
+    puts
+  when :section
+    puts
+    puts "# #{title}"
+  else
+    fail
+  end
+  v.each_with_index do |(ref, ti), n|
+    ti = "[#{ti}](##{ref})" if ref
+    puts "#{n+1}. #{ti}"
+    # XXX add references
+  end
+end

--- a/bin/kramdown-rfc-extract-figures-tables
+++ b/bin/kramdown-rfc-extract-figures-tables
@@ -2,7 +2,6 @@
 require 'rexml/document'
 require 'yaml'
 require 'optparse'
-require 'pp'
 
 PROGNAME = "kramdown-rfc-extract-figures-tables"
 
@@ -75,6 +74,5 @@ lists.each do |k, v|
   v.each_with_index do |(ref, ti), n|
     ti = "[#{ti}](##{ref})" if ref
     puts "#{n+1}. #{ti}"
-    # XXX add references
   end
 end

--- a/bin/kramdown-rfc-extract-figures-tables
+++ b/bin/kramdown-rfc-extract-figures-tables
@@ -68,6 +68,7 @@ lists.each do |k, v|
   when :section
     puts
     puts "# #{title}"
+    puts "{:unnumbered}"
   else
     fail
   end

--- a/kramdown-rfc2629.gemspec
+++ b/kramdown-rfc2629.gemspec
@@ -14,11 +14,23 @@ spec = Gem::Specification.new do |s|
   s.add_dependency('net-http-persistent', '~> 4.0')
   s.add_dependency('differ', '~> 0.1')
   s.add_dependency('base64', '>= 0.1')
-  s.files = Dir['lib/**/*.rb'] + %w(README.md LICENSE kramdown-rfc2629.gemspec bin/kdrfc bin/kramdown-rfc bin/kramdown-rfc2629 bin/doilit bin/echars bin/kramdown-rfc-extract-markdown bin/kramdown-rfc-extract-sourcecode bin/kramdown-rfc-lsr data/kramdown-rfc2629.erb data/encoding-fallbacks.txt data/math.json bin/kramdown-rfc-cache-subseries-bibxml bin/kramdown-rfc-autolink-iref-cleanup bin/de-gfm bin/kramdown-rfc-clean-svg-ids)
+  s.files = Dir['lib/**/*.rb'] +
+            %w(README.md LICENSE kramdown-rfc2629.gemspec
+               bin/kdrfc bin/kramdown-rfc bin/kramdown-rfc2629
+               bin/doilit bin/echars bin/kramdown-rfc-extract-markdown
+               bin/kramdown-rfc-extract-sourcecode
+               bin/kramdown-rfc-extract-figures-tables
+               bin/kramdown-rfc-lsr data/kramdown-rfc2629.erb
+               data/encoding-fallbacks.txt data/math.json
+               bin/kramdown-rfc-cache-subseries-bibxml
+               bin/kramdown-rfc-autolink-iref-cleanup
+               bin/de-gfm
+               bin/kramdown-rfc-clean-svg-ids)
   s.require_path = 'lib'
   s.executables = ['kramdown-rfc', 'kramdown-rfc2629', 'doilit', 'echars',
                    'kramdown-rfc-extract-markdown',
                    'kramdown-rfc-extract-sourcecode',
+                   'kramdown-rfc-extract-figures-tables',
                    'kramdown-rfc-lsr',
                    'kdrfc', 'kramdown-rfc-cache-i-d-bibxml',
                    'kramdown-rfc-cache-subseries-bibxml',


### PR DESCRIPTION
Add kramdown-rfc-extract-figures-tables, a tool for generating lists of figures and of tables.
The output of that tool can be included either after the abstract (format "note") or before the unnumbered back matter (format "section", default) [or both :-)].
