### PR TITLE
Add a way to suppress refcache fetching messages

### DIFF
--- a/kramdown-rfc.gemspec
+++ b/kramdown-rfc.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc'
-  s.version = '1.7.23'
+  s.version = '1.7.24'
   s.summary = "Kramdown extension for generating RFCXML (RFC 799x)."
   s.description = %{An RFCXML (RFC 799x) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}

--- a/kramdown-rfc2629.gemspec
+++ b/kramdown-rfc2629.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc2629'
-  s.version = '1.7.23'
+  s.version = '1.7.24'
   s.summary = "Kramdown extension for generating RFCXML (RFC 799x)."
   s.description = %{An RFCXML (RFC 799x) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -1251,7 +1251,7 @@ COLORS
             message = "fetching"
             fetch_timeout = 60 # seconds; long timeout needed for Travis
           end
-          $stderr.puts "#{fn}: #{message} from #{url}"
+          $stderr.puts "#{fn}: #{message} from #{url}" unless ENV["KRAMDOWN_REFCACHE_QUIET"]
           if Array === url
             begin
               case url[0]

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -1203,6 +1203,7 @@ COLORS
 
       KRAMDOWN_OFFLINE = ENV["KRAMDOWN_OFFLINE"]
       KRAMDOWN_REFCACHE_REFETCH = ENV["KRAMDOWN_REFCACHE_REFETCH"]
+      KRAMDOWN_REFCACHE_QUIET = ENV["KRAMDOWN_REFCACHE_QUIET"]
 
       def get_and_write_resource(url, fn)
         options = {}
@@ -1251,7 +1252,7 @@ COLORS
             message = "fetching"
             fetch_timeout = 60 # seconds; long timeout needed for Travis
           end
-          $stderr.puts "#{fn}: #{message} from #{url}" unless ENV["KRAMDOWN_REFCACHE_QUIET"]
+          $stderr.puts "#{fn}: #{message} from #{url}" unless KRAMDOWN_REFCACHE_QUIET
           if Array === url
             begin
               case url[0]


### PR DESCRIPTION
These messages are not abnormal.  All other `$stderr.puts` calls made in this code relate to genuine problems that authors might need to pay attention to (why those aren't using `warn` is something that might need to be looked into) but the messages for downloading are not something that anyone can do anything about.  This does not change the warning that is emitted for failed downloads or other such errors.

Obviously, I'd be happy to have you suggest an alternative spelling here.