### PR TITLE
Allow setting of a custom ERB file via an environment variable

### DIFF
--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -509,7 +509,11 @@ def xml_from_sections(input)
     end
   end
 
-  erbfilename = File.expand_path '../../../data/kramdown-rfc2629.erb', __FILE__
+  if ENV["KRAMDOWN_ERB_FILE"]
+    erbfilename = ENV["KRAMDOWN_ERB_FILE"]
+  else
+    erbfilename = File.expand_path '../../../data/kramdown-rfc2629.erb', __FILE__
+  end
   erbfile = File.read(erbfilename, coding: "UTF-8")
   erb = ERB.trim_new(erbfile, '-')
   # remove redundant nomarkdown pop outs/pop ins as they confuse kramdown


### PR DESCRIPTION
I don't know how open you are to PRs that have little to do with generating RFCs, but rather more to do with RFC-like documents based on the same tooling. But this very simple change would certainly help with that!

It'll allow processing of YAML front matter in the erb file for which there is no direct support in kramdown-rfc. I use it to generate mildly different v3 xml files which xml2rfc still processes.

I'd be happy to work suggestions into the PR to make it more acceptable, too.