### PR TITLE
Fix name heuristic generation and make doc less ambiguous

### DIFF
--- a/bin/kramdown-rfc-extract-sourcecode
+++ b/bin/kramdown-rfc-extract-sourcecode
@@ -20,9 +20,10 @@ def slugify_like_xml2rfc(s, delta = 0)
   s.gsub!(/[^-\w\s\/]/, '')
   s = s.strip
   s.gsub!(/[-\s\/]/, '-')
-  n = 32 - delta
+  ni = 32 - delta
+  n = ni
   nmax = [s.size, 40 - delta].min
-  while $seen_slugs[slugex = s[0...n]] && n < nmax
+  while $seen_slugs[slugex = s[0...ni]] && n < nmax
     n += 1
   end
   if $seen_slugs[slugex]
@@ -53,7 +54,7 @@ begin
     opts.on("-dDIR", "--dir=DIR", "Target directory (default: sourcecode)") do |v|
       dir = v
     end
-    opts.on("-xTYPE/NAME", "--extract=TYPE/NAME", "Extract single item to stdout") do |v|
+    opts.on("-xTYPE/NAME", "--extract=\"TYPE/NAME\"", "Extract single item of type TYPE and name NAME to stdout") do |v|
       target = :stdout
       out_type, out_name = v.split("/", 2)
     end


### PR DESCRIPTION
Before fix:

```
$ kramdown-rfc-extract-sourcecode draft-ietf-scitt-architecture-22.xml 
---
cddl:
- cddl-definition-for-signed-.cddl
- cddl-definition-for-a-trans.cddl
cbor-diag:
- cbor-extended-diagnostic-no.cbor-diag
- cbor-extended-diagnostic-not.cbor-diag
- cbor-extended-diagnostic-nota.cbor-diag
- cbor-extended-diagnostic-notat.cbor-diag
- cbor-extended-diagnostic-notati.cbor-diag
- cbor-extended-diagnostic-notatio.cbor-diag
svg:
- example-ssc-life-cycle-thre.svg
- relationship-of-concepts-in.svg
- signing-large-or-sensitive-.svg
ascii-art:
- example-ssc-life-cycle-thre.ascii-art
- relationship-of-concepts-in.ascii-art
```

After fix:

```
# ruby kramdown-rfc/bin/kramdown-rfc-extract-sourcecode draft-ietf-scitt-architecture-22.xml 
---
cddl:
- cddl-definition-for-signed-.cddl
- cddl-definition-for-a-trans.cddl
cbor-diag:
- cbor-extended-diagnostic-no.cbor-diag
- cbor-extended-diagnostic-notation-e-2.cbor-diag
- cbor-extended-diagnostic-notation-e-3.cbor-diag
- cbor-extended-diagnostic-notation-e-4.cbor-diag
- cbor-extended-diagnostic-notation-e-5.cbor-diag
- cbor-extended-diagnostic-notation-e-6.cbor-diag
svg:
- example-ssc-life-cycle-thre.svg
- relationship-of-concepts-in.svg
- signing-large-or-sensitive-.svg
ascii-art:
- example-ssc-life-cycle-thre.ascii-art
- relationship-of-concepts-in.ascii-art
- signing-large-or-sensitive-.ascii-art
```