### PR TITLE
Remove certified

### DIFF
--- a/kramdown-rfc.gemspec
+++ b/kramdown-rfc.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc'
-  s.version = '1.7.34'
+  s.version = '1.7.35'
   s.summary = "Kramdown extension for generating RFCXML (RFC 799x)."
   s.description = %{An RFCXML (RFC 799x) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}

--- a/kramdown-rfc2629.gemspec
+++ b/kramdown-rfc2629.gemspec
@@ -1,6 +1,6 @@
 spec = Gem::Specification.new do |s|
   s.name = 'kramdown-rfc2629'
-  s.version = '1.7.34'
+  s.version = '1.7.35'
   s.summary = "Kramdown extension for generating RFCXML (RFC 799x)."
   s.description = %{An RFCXML (RFC 799x) generating backend for Thomas Leitner's
 "kramdown" markdown parser.  Mostly useful for RFC writers.}

--- a/kramdown-rfc2629.gemspec
+++ b/kramdown-rfc2629.gemspec
@@ -6,7 +6,6 @@ spec = Gem::Specification.new do |s|
 "kramdown" markdown parser.  Mostly useful for RFC writers.}
   s.add_dependency('kramdown', '~> 2.4.0')
   s.add_dependency('kramdown-parser-gfm', '~> 1.1')
-  s.add_dependency('certified', '~> 1.0')
   s.add_dependency('json_pure', '~> 2.0')
   s.add_dependency('unicode-name', '~> 1.0')
   s.add_dependency('unicode-blocks', '~> 1.0')

--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -180,16 +180,8 @@ def do_the_tls_dance
     File.open(OpenSSL::X509::DEFAULT_CERT_FILE) do end
     # This guards against having an unreadable cert file (yes, that appears to happen a lot).
   rescue
-    if Dir[File.join(OpenSSL::X509::DEFAULT_CERT_DIR, "*.pem")].empty?
-      # This guards against having no certs at all, not against missing the right one for IETF.
-      # Oh well.
-      warn "** Configuration problem with OpenSSL certificate store."
-      warn "**   You may want to examine #{OpenSSL::X509::DEFAULT_CERT_FILE}"
-      warn "**    and #{OpenSSL::X509::DEFAULT_CERT_DIR}."
-      warn "**   Activating suboptimal workaround."
-      warn "**   Occasionally run `certified-update` to maintain that workaround."
-      require 'certified'
-    end
+    warn "** Configuration problem with OS certificate store."
+    exit 71 # EX_OSERR
   end
 end
 

--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -180,7 +180,7 @@ def do_the_tls_dance
     File.open(OpenSSL::X509::DEFAULT_CERT_FILE) do end
     # This guards against having an unreadable cert file (yes, that appears to happen a lot).
   rescue
-    warn "** Configuration problem with OS certificate store."
+    warn "*** Configuration problem with OS certificate store."
     exit 71 # EX_OSERR
   end
 end


### PR DESCRIPTION
Most operating systems are correctly configured.

You already require Ruby 2.5.
OpenSSL has been included since 2.4
(released 2016-12-25, end of life 2020-03-31).