### PR TITLE
feat: add hard RFC8792 folding option

### DIFF
--- a/README.md
+++ b/README.md
@@ -549,6 +549,40 @@ machine-generated:
 {: #example2 title="A longer RPL example"}
 ```
 
+Include flags can be appended to the command name:
+
+```markdown
+{::include-dedent-lines3..8 generated.txt}
+{::include-fold69left4dryhard generated.json}
+```
+
+Supported include flags are:
+
+* `nested`: process include commands in the included text.
+* `dedent`: remove common leading indentation from the included text.
+* `quote`: prefix each included line with `> `.
+* `xml`: parse the included text as XML and include the serialized XML
+  content without XML declaration or doctype.
+* `linesN..M`, `linesN...M`: include only the selected 1-based line
+  range; the three-dot form excludes the end line.
+* `data`: base64-encode the included text as a data URI attribute value.
+* `all`: expand the path as a glob and include all matching files.
+* `last`: expand the path as a glob and include only the last matching file.
+* `fold`: fold the included text using RFC 8792 single-backslash line
+  wrapping.
+
+The `fold` flag accepts options in the form
+`fold[columns][left[spaces]][dry][hard]`:
+
+* `columns`: target fold column; omitted or `0` uses the default of 69.
+* `left`: use a fixed continuation indentation; `left` without a number
+  means zero spaces, and `left4` means four spaces.
+* `dry`: use the plain RFC 8792 notice instead of padding it with `=`
+  characters.
+* `hard`: fold at the requested column.  Without this option, folding may
+  move the break earlier when the requested column falls within a sequence of
+  letters, digits, or `_`, so that the sequence stays intact.
+
 (0.x:) A page break can be forced by adding a horizontal rule (`----`,
 note that this creates ugly blank space in some HTML converters).
 

--- a/README.md
+++ b/README.md
@@ -564,7 +564,9 @@ Supported include flags are:
 * `xml`: parse the included text as XML and include the serialized XML
   content without XML declaration or doctype.
 * `linesN..M`, `linesN...M`: include only the selected 1-based line
-  range; the three-dot form excludes the end line.
+  range; the three-dot form excludes the end line.  `N` and `M` can be
+  left out and then stand for the start and end, respectively; e.g.,
+  `lines2..` includes from line 2 through the end.
 * `data`: base64-encode the included text as a data URI attribute value.
 * `all`: expand the path as a glob and include all matching files.
 * `last`: expand the path as a glob and include only the last matching file.
@@ -575,13 +577,14 @@ The `fold` flag accepts options in the form
 `fold[columns][left[spaces]][dry][hard]`:
 
 * `columns`: target fold column; omitted or `0` uses the default of 69.
-* `left`: use a fixed continuation indentation; `left` without a number
-  means zero spaces, and `left4` means four spaces.
+* `left`: instead of aligning continuation lines to the right, use a fixed
+  continuation indentation; `left` without a number means zero spaces, and
+  `left4` means four spaces.
 * `dry`: use the plain RFC 8792 notice instead of padding it with `=`
   characters.
-* `hard`: fold at the requested column.  Without this option, folding may
-  move the break earlier when the requested column falls within a sequence of
-  letters, digits, or `_`, so that the sequence stays intact.
+* `hard`: fold at the requested column unconditionally.  Without this option,
+  folding may move the break earlier when the requested column falls within a
+  sequence of letters, digits, or `_`, so that the sequence stays intact.
 
 (0.x:) A page break can be forced by adding a horizontal rule (`----`,
 note that this creates ugly blank space in some HTML converters).

--- a/README.md
+++ b/README.md
@@ -553,7 +553,7 @@ Include flags can be appended to the command name:
 
 ```markdown
 {::include-dedent-lines3..8 generated.txt}
-{::include-fold69left4dryhard generated.json}
+{::include-fold69hardleft4dry generated.json}
 ```
 
 Supported include flags are:
@@ -574,17 +574,17 @@ Supported include flags are:
   wrapping.
 
 The `fold` flag accepts options in the form
-`fold[columns][left[spaces]][dry][hard]`:
+`fold[columns][hard][left[spaces]][dry]`:
 
 * `columns`: target fold column; omitted or `0` uses the default of 69.
+* `hard`: fold at the requested column unconditionally.  Without this option,
+  folding may move the break earlier when the requested column falls within a
+  sequence of letters, digits, or `_`, so that the sequence stays intact.
 * `left`: instead of aligning continuation lines to the right, use a fixed
   continuation indentation; `left` without a number means zero spaces, and
   `left4` means four spaces.
 * `dry`: use the plain RFC 8792 notice instead of padding it with `=`
   characters.
-* `hard`: fold at the requested column unconditionally.  Without this option,
-  folding may move the break earlier when the requested column falls within a
-  sequence of letters, digits, or `_`, so that the sequence stays intact.
 
 (0.x:) A page break can be forced by adding a horizontal rule (`----`,
 note that this creates ugly blank space in some HTML converters).

--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -65,11 +65,11 @@ def process_includes(input)
                         $2)
     when "data"
       data = true
-    when /\Afold(\d*)(left(\d*))?(dry)?(hard)?\z/
-      fold = [$1.to_i,            # col 0 for ''
-              ($3.to_i if $2),    # left 0 for '', nil if no "left"
-              $4,                 # dry
-              $5]                 # hard
+    when /\Afold(?<columns>\d*)(?<hard>hard)?(?<left>left(?<spaces>\d*))?(?<dry>dry)?\z/
+      md = Regexp.last_match
+      columns = md[:columns].to_i
+      left = md[:spaces].to_i if md[:left]
+      fold = [columns, left, md[:dry], md[:hard]]
     when "all", "last"
       fn = fn.flat_map{|n| Dir[n]}
       fn = [fn.last] if flag == "last"

--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -65,10 +65,11 @@ def process_includes(input)
                         $2)
     when "data"
       data = true
-    when /\Afold(\d*)(left(\d*))?(dry)?\z/
+    when /\Afold(\d*)(left(\d*))?(dry)?(hard)?\z/
       fold = [$1.to_i,            # col 0 for ''
               ($3.to_i if $2),    # left 0 for '', nil if no "left"
-              $4]                 # dry
+              $4,                 # dry
+              $5]                 # hard
     when "all", "last"
       fn = fn.flat_map{|n| Dir[n]}
       fn = [fn.last] if flag == "last"

--- a/lib/kramdown-rfc/rfc8792.rb
+++ b/lib/kramdown-rfc/rfc8792.rb
@@ -44,7 +44,7 @@ MIN_FOLD_COLUMNS = FOLD_MSG.size
 FOLD_COLUMNS = 69
 RE_IDENT = /\A[A-Za-z0-9_]\z/
 
-def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false)
+def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false, hard = false)
   if s.index("\t")
     warn "*** HT (\"TAB\") in text to be folded. Giving up."
     return s
@@ -80,7 +80,7 @@ def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false)
       if col <= min_indent
         warn "*** Cannot RFC8792-fold1 to #{columns} cols #{"with indent #{left}" if left}  |#{li.inspect}|"
       else
-        if RE_IDENT === li[col] # Don't split IDs
+        if !hard && RE_IDENT === li[col] # Don't split IDs
           col2 = col
           while col2 > min_indent && RE_IDENT === li[col2-1]
             col2 -= 1

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -795,10 +795,11 @@ COLORS
         case proc
         when "dedent"
           result = remove_indentation(result)
-        when /\Afold(\d*)(left(\d*))?(dry)?\z/
+        when /\Afold(\d*)(left(\d*))?(dry)?(hard)?\z/
           fold = [$1.to_i,            # col 0 for ''
                   ($3.to_i if $2),    # left 0 for '', nil if no "left"
-                  $4]                 # dry
+                  $4,                 # dry
+                  $5]                 # hard
           result = fix_unterminated_line(fold8792_1(trim_empty_lines_around(result), *fold)) # XXX
         when /\Alines(\d*)\.\.(\.)?(\d*)\z/
           range = Range.new($1.empty? ? nil : $1.to_i, # compensate for

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -795,11 +795,11 @@ COLORS
         case proc
         when "dedent"
           result = remove_indentation(result)
-        when /\Afold(\d*)(left(\d*))?(dry)?(hard)?\z/
-          fold = [$1.to_i,            # col 0 for ''
-                  ($3.to_i if $2),    # left 0 for '', nil if no "left"
-                  $4,                 # dry
-                  $5]                 # hard
+        when /\Afold(?<columns>\d*)(?<hard>hard)?(?<left>left(?<spaces>\d*))?(?<dry>dry)?\z/
+          md = Regexp.last_match
+          columns = md[:columns].to_i
+          left = md[:spaces].to_i if md[:left]
+          fold = [columns, left, md[:dry], md[:hard]]
           result = fix_unterminated_line(fold8792_1(trim_empty_lines_around(result), *fold)) # XXX
         when /\Alines(\d*)\.\.(\.)?(\d*)\z/
           range = Range.new($1.empty? ? nil : $1.to_i, # compensate for


### PR DESCRIPTION
Adds a `hard` option to RFC 8792 folding.

By default, kramdown-rfc avoids splitting identifier-like sequences when a fold point falls inside letters, digits, or `_`. That is useful for many source-code examples, but it produces early folds for base64url-heavy examples because `-` acts as a convenient earlier break point.

For JSON examples whose long values contain only base64url characters, hard folding gives a more regular presentation while still using RFC 8792 single-backslash wrapping.

**Example**

```markdown
~~~ json
{::include-fold69hardleft4 examples/jwks/HPKE-8.json}
~~~
```

<details>
<summary>examples/jwks/HPKE-8.json source</summary>

```json
{
  "kty": "AKP",
  "alg": "HPKE-8",
  "kid": "DmOWQi-VwrjZWjO6mQQWdv3CJ_v9k_PH3vS7S0xoah8",
  "pub": "6XRnIatC1KtI7DZlj8ISDxZvtsFeBOPKQETMRRYb45dR0kw6TDSb8UMXHHWhUBdbEBof5gvIJacZG4exGku4JsysQcc9AVR6Ydih7kaPNQgCiiKw9QACNCMWx2p171RVCpGSFoOwaejNGZeNJKS4jqulOWFQHGtbWhl64HZzlkZMxhqdA-EecEOLhzCkbCMMtXxb-cxUVkOxQpKkO5ofmEaKH7tjyNZyVsxqgUZFn6K8jOq9g6GCOEG4awGB6AZC72yNXLDBnVCy_7OMn2bAeos8AvhHkbsL0hsFFjsnWcG_IYvNPzUAcyGZlpsqjXJIh4AUxTi6iFeJFOE08nNM3KQEYlxkMAulVas2E4KU_TGeoEJeZjA5TPWVAQiPFFQ4nNRh1kotf4OHtHQVpaMzAypItIXAU8LI_gl4rdFKTfYu18MKnygjEnO9Z7e2cYwj_hqx-AQdA6ulQBcNR4DFSCOTLnMB22GMXGVOMDCmiaxZvchp9iEKNJG4TkZQmoKwR9pbEbahmsm1WvUbR6kEqNYOE0MMsRWNM3RBNltm0Iqo8RKMlpRq5RceWRRdjRkKdChyhuJ2ebBI05iRsuE6AwWEbCV6dQqNZ0gqdeU5imECjFWLNqYvs0BaxDgmoSdg4rFlq3UrZ3gLD4UTT4kM97HO5iedxoox__octTEEImMTf8uJI2M0nKTIpbWBHlofTfulcqVXjFYpr9GvuKM_mElaoJwn3MQYrFNLcwY-fzy9fqvGFtF-62fHcpcL7SVUu9KW7igiAHQfwXmCnMQzsxwLowVk8mFjDYgV2iIoNIeuwZdc8-I0A1CLiqOQNwCLObgSMVeo-WUvzmocsFOUtSUS1chNNwpjMCGKuHxOYOcvKLxH7mvPp6czIovPsqQUZdloA5Wqt8U1sDRZfrhRlUi4IVoTmevBpaEYK_Jze3cIMOkRKdO5Y1tB4TIcAHE8oNUarUEYx1YDUinIolRBBDyBAmR7rbV4iGenGHwgeTIZ0cpppFEDbkAX4AaG4YKGdGWrgWhhiDoPX2mda_BLOSilnlhmM2BhqGZBkKK2E1B5fgER-_AMYeVl9HEoKCFHm6KApgnLVnYMQjEv7kC6tsqxs-pOcnSs2EpGKMMk4gdIlcFNxsVU6sXINHADvNmtNyQgjRFKhmNPtYchXHWz_tgccWNkm1DD6qMATOoZcscAu8BBpKUwUIkIUICwKpay5KUsFjKpC9HPqSONVMVu7GYysVC8UDTMetWoXlSiDetoiolwFGGpIscf1ic_rUhbD3pyxVI8DqCsdFg2NcSvIJRoJBO12KHKRIYnc8ObgCzJBULNZ1Rmc5tCbmcW_mmhg0OiA7EJjwi_eoY82_g0eiyAr0K4DmBy8yqWDZV45KfAnYQBQZvK8zlj0npGqVWusxzP1mw_Dbhnp-Z6SyIrHNI9unG7DbeDhcnBD2QBp2t6cNgvUoCLzPReQPYy_bwVEwcrPSO4SjUG8mhuybiU5NWdgIRD95gD1ApNRoZeJIhfP7yM1vt1ZCxfV0xEvUSb25DOebimyplEvv7nxam2hbnlRQme00B5wPt9pETxPSQE4ZUd6u60U9e6F3C-Fqjwfg_xYMk3oOcZQ-P5NrsNxK3ho7xmtpSKVahpf_2P_o2Vz8YFc7t2S7jAx9bRLQQpbA",
  "priv": "c1il1CJwUdajeAm8PMZMq4mw2PH9Z2vThLkHU2MQ10A"
}
```

</details>

This means:

- `69`: fold at column 69
- `hard`: fold at the requested column instead of moving the break earlier to keep identifier-like sequences intact
- `left4`: indent continuation lines by four spaces

Using `examples/jwks/HPKE-8.json`, this would produce:

```json
=============== NOTE: '\' line wrapping per RFC 8792 ================

{
  "kty": "AKP",
  "alg": "HPKE-8",
  "kid": "DmOWQi-VwrjZWjO6mQQWdv3CJ_v9k_PH3vS7S0xoah8",
  "pub": "6XRnIatC1KtI7DZlj8ISDxZvtsFeBOPKQETMRRYb45dR0kw6TDSb8UMXHH\
    WhUBdbEBof5gvIJacZG4exGku4JsysQcc9AVR6Ydih7kaPNQgCiiKw9QACNCMWx2\
    p171RVCpGSFoOwaejNGZeNJKS4jqulOWFQHGtbWhl64HZzlkZMxhqdA-EecEOLhz\
    CkbCMMtXxb-cxUVkOxQpKkO5ofmEaKH7tjyNZyVsxqgUZFn6K8jOq9g6GCOEG4aw\
    GB6AZC72yNXLDBnVCy_7OMn2bAeos8AvhHkbsL0hsFFjsnWcG_IYvNPzUAcyGZlp\
    sqjXJIh4AUxTi6iFeJFOE08nNM3KQEYlxkMAulVas2E4KU_TGeoEJeZjA5TPWVAQ\
    iPFFQ4nNRh1kotf4OHtHQVpaMzAypItIXAU8LI_gl4rdFKTfYu18MKnygjEnO9Z7\
    e2cYwj_hqx-AQdA6ulQBcNR4DFSCOTLnMB22GMXGVOMDCmiaxZvchp9iEKNJG4Tk\
    ZQmoKwR9pbEbahmsm1WvUbR6kEqNYOE0MMsRWNM3RBNltm0Iqo8RKMlpRq5RceWR\
    RdjRkKdChyhuJ2ebBI05iRsuE6AwWEbCV6dQqNZ0gqdeU5imECjFWLNqYvs0BaxD\
    gmoSdg4rFlq3UrZ3gLD4UTT4kM97HO5iedxoox__octTEEImMTf8uJI2M0nKTIpb\
    WBHlofTfulcqVXjFYpr9GvuKM_mElaoJwn3MQYrFNLcwY-fzy9fqvGFtF-62fHcp\
    cL7SVUu9KW7igiAHQfwXmCnMQzsxwLowVk8mFjDYgV2iIoNIeuwZdc8-I0A1CLiq\
    OQNwCLObgSMVeo-WUvzmocsFOUtSUS1chNNwpjMCGKuHxOYOcvKLxH7mvPp6czIo\
    vPsqQUZdloA5Wqt8U1sDRZfrhRlUi4IVoTmevBpaEYK_Jze3cIMOkRKdO5Y1tB4T\
    IcAHE8oNUarUEYx1YDUinIolRBBDyBAmR7rbV4iGenGHwgeTIZ0cpppFEDbkAX4A\
    aG4YKGdGWrgWhhiDoPX2mda_BLOSilnlhmM2BhqGZBkKK2E1B5fgER-_AMYeVl9H\
    EoKCFHm6KApgnLVnYMQjEv7kC6tsqxs-pOcnSs2EpGKMMk4gdIlcFNxsVU6sXINH\
    ADvNmtNyQgjRFKhmNPtYchXHWz_tgccWNkm1DD6qMATOoZcscAu8BBpKUwUIkIUI\
    CwKpay5KUsFjKpC9HPqSONVMVu7GYysVC8UDTMetWoXlSiDetoiolwFGGpIscf1i\
    c_rUhbD3pyxVI8DqCsdFg2NcSvIJRoJBO12KHKRIYnc8ObgCzJBULNZ1Rmc5tCbm\
    cW_mmhg0OiA7EJjwi_eoY82_g0eiyAr0K4DmBy8yqWDZV45KfAnYQBQZvK8zlj0n\
    pGqVWusxzP1mw_Dbhnp-Z6SyIrHNI9unG7DbeDhcnBD2QBp2t6cNgvUoCLzPReQP\
    Yy_bwVEwcrPSO4SjUG8mhuybiU5NWdgIRD95gD1ApNRoZeJIhfP7yM1vt1ZCxfV0\
    xEvUSb25DOebimyplEvv7nxam2hbnlRQme00B5wPt9pETxPSQE4ZUd6u60U9e6F3\
    C-Fqjwfg_xYMk3oOcZQ-P5NrsNxK3ho7xmtpSKVahpf_2P_o2Vz8YFc7t2S7jAx9\
    bRLQQpbA",
  "priv": "c1il1CJwUdajeAm8PMZMq4mw2PH9Z2vThLkHU2MQ10A"
}
```

The folded output remains reversible with the existing RFC 8792 unfolding logic.
