### PR TITLE
feat: add smart left indent RFC8792 folding

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -23,5 +23,7 @@ html:   $(HTML)
 
 sou:    fold.xml
 	kramdown-rfc-extract-sourcecode -dsou $<
-	(cd sou/test-vectors; for i in *.test-vectors; do diff $$i testing-fold.test-vectors; echo $$i; done)
+
+fold-check: sou
+	(cd sou/test-vectors; for i in *.test-vectors; do diff -s $$i testing-fold.test-vectors; done)
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -16,3 +16,12 @@ html:   $(HTML)
 
 %.txt:	%.xml
 	xml2rfc $<
+
+%.xml:	%.md
+	kramdown-rfc2629 $< >$@.new
+	mv $@.new $@
+
+sou:    fold.xml
+	kramdown-rfc-extract-sourcecode -dsou $<
+	(cd sou/test-vectors; for i in *.test-vectors; do diff $$i testing-fold.test-vectors; echo $$i; done)
+

--- a/examples/fold.md
+++ b/examples/fold.md
@@ -1,0 +1,63 @@
+---
+coding: utf-8
+v: 3
+
+title: Many fine lunches and dinners
+abbrev: mfld
+docname: draft-mfld-00
+category: info
+stream: IETF
+
+author:
+  - name: Carsten Bormann
+    org: Universität Bremen TZI
+    street: Postfach 330440
+    city: Bremen
+    code: D-28359
+    country: Germany
+    phone: +49-421-218-63921
+    email: cabo@tzi.org
+
+--- abstract
+
+insert abstract here
+
+--- middle
+
+# Introduction
+
+{::boilerplate bcp14-tagged-bcp14}
+
+## Testing fold
+
+~~~
+aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   bbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      cccccccccc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+ ddddddddddddddd dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+~~~
+{: post="fold40hardleft2dry" title="fold40hardleft2dry"}
+
+~~~
+aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   bbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      cccccccccc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  dddddddddddddd ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+~~~
+{: post="fold40smart2dry" title="fold40smart2dry"}
+
+~~~
+aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   bbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      cccccccccc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  dddddddddddddd ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+~~~
+{: post="fold40hardsmart2dry" title="fold40hardsmart2dry"}
+
+~~~
+aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+   bbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
+      cccccccccc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
+  dddddddddddddd ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+~~~
+{: post="fold40dry" title="fold40dry"}

--- a/examples/fold.md
+++ b/examples/fold.md
@@ -30,15 +30,21 @@ insert abstract here
 
 ## Testing fold
 
-~~~
+~~~ test-vectors
+short line
+short line with one \
+short line with two \\
 aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
    bbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
       cccccccccc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
- ddddddddddddddd dddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
+  dddddddddddddd ddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddddd
 ~~~
 {: post="fold40hardleft2dry" title="fold40hardleft2dry"}
 
-~~~
+~~~ test-vectors
+short line
+short line with one \
+short line with two \\
 aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
    bbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
       cccccccccc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -46,7 +52,10 @@ aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ~~~
 {: post="fold40smart2dry" title="fold40smart2dry"}
 
-~~~
+~~~ test-vectors
+short line
+short line with one \
+short line with two \\
 aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
    bbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
       cccccccccc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc
@@ -54,7 +63,10 @@ aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
 ~~~
 {: post="fold40hardsmart2dry" title="fold40hardsmart2dry"}
 
-~~~
+~~~ test-vectors
+short line
+short line with one \
+short line with two \\
 aaaaaaaaaaaaaaaa aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
    bbbbbbbbbbbbb bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb
       cccccccccc ccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccccc

--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -65,11 +65,8 @@ def process_includes(input)
                         $2)
     when "data"
       data = true
-    when /\Afold(?<columns>\d*)(?<hard>hard)?(?<left>left(?<spaces>\d*))?(?<dry>dry)?\z/
-      md = Regexp.last_match
-      columns = md[:columns].to_i
-      left = md[:spaces].to_i if md[:left]
-      fold = [columns, left, md[:dry], md[:hard]]
+    when ::FOLD8792_PROC_RE
+      fold = fold8792_options(flag)
     when "all", "last"
       fn_in = fn
       fn = fn.flat_map{|n| Dir[n]}

--- a/lib/kramdown-rfc/command.rb
+++ b/lib/kramdown-rfc/command.rb
@@ -66,7 +66,7 @@ def process_includes(input)
     when "data"
       data = true
     when ::FOLD8792_PROC_RE
-      fold = fold8792_options(flag)
+      fold = fold8792_options(Regexp.last_match)
     when "all", "last"
       fn_in = fn
       fn = fn.flat_map{|n| Dir[n]}

--- a/lib/kramdown-rfc/rfc8792.rb
+++ b/lib/kramdown-rfc/rfc8792.rb
@@ -22,6 +22,23 @@ end
 
 FOLD_MSG = "NOTE: '\\' line wrapping per RFC 8792".freeze
 UNFOLD_RE = /\A.*#{FOLD_MSG.sub("\\", "(\\\\\\\\\\\\\\\\?)")}.*\n\r?\n/
+FOLD8792_PROC_RE = /\Afold(?<columns>\d*)(?<hard>hard)?(?<indent>(?<indent_type>left|smart)(?<spaces>\d*))?(?<dry>dry)?\z/
+
+def fold8792_options(proc)
+  md = FOLD8792_PROC_RE.match(proc)
+  return unless md
+
+  columns = md[:columns].to_i
+  left =
+    case md[:indent_type]
+    when "left"
+      md[:spaces].to_i
+    when "smart"
+      [:smart, md[:spaces].to_i]
+    end
+
+  [columns, left, md[:dry], md[:hard]]
+end
 
 def unfold8792(s)
   if s =~ UNFOLD_RE
@@ -61,6 +78,8 @@ def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false, hard = fals
 
   lines = s.lines.map(&:chomp)
   did_fold = false
+  smart_indent_offset = left[1] if Array === left && left[0] == :smart
+  smart_indent = nil
   ix = 0
   while li = lines[ix]
     col = columns
@@ -69,16 +88,25 @@ def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false, hard = fals
         lines[ix..ix] = [li << "\\", ""]
         ix += 1
       end
+      smart_indent = nil
       ix += 1
     else
       did_fold = true
-      min_indent = left || 0
+      left_indent =
+        if !smart_indent_offset.nil?
+          smart_indent ||= li[/\A */].size + smart_indent_offset
+        else
+          left
+        end
+      min_indent = left_indent || 0
       col -= 1                  # space for "\\"
       while li[col] == " "      # can't start new line with " "
         col -= 1
       end
       if col <= min_indent
-        warn "*** Cannot RFC8792-fold1 to #{columns} cols #{"with indent #{left}" if left}  |#{li.inspect}|"
+        indent_msg = "with indent #{min_indent}" if left
+        warn "*** Cannot RFC8792-fold1 to #{columns} cols #{indent_msg}  |#{li.inspect}|"
+        smart_indent = nil
       else
         if !hard && RE_IDENT === li[col] # Don't split IDs
           col2 = col
@@ -90,8 +118,8 @@ def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false, hard = fals
           end
         end
         rest = li[col..-1]
-        indent = left || columns - rest.size
-        if !left && li[-1] == "\\"
+        indent = left_indent || columns - rest.size
+        if !left_indent && li[-1] == "\\"
           indent -= 1           # leave space for next round
         end
         if indent > 0

--- a/lib/kramdown-rfc/rfc8792.rb
+++ b/lib/kramdown-rfc/rfc8792.rb
@@ -22,7 +22,7 @@ end
 
 FOLD_MSG = "NOTE: '\\' line wrapping per RFC 8792".freeze
 UNFOLD_RE = /\A.*#{FOLD_MSG.sub("\\", "(\\\\\\\\\\\\\\\\?)")}.*\n\r?\n/
-FOLD8792_PROC_RE = /\Afold(?<columns>\d*)(?<hard>hard)?(?<indent>(?<indent_type>left|smart)(?<spaces>\d*))?(?<dry>dry)?\z/
+FOLD8792_PROC_RE = /\Afold(?<columns>\d*)(?<hard>hard)?(?:(?<indent_type>left|smart)(?<spaces>\d*))?(?<dry>dry)?\z/
 
 def fold8792_options(md)
   indent_type = md[:indent_type].to_sym if md[:indent_type]

--- a/lib/kramdown-rfc/rfc8792.rb
+++ b/lib/kramdown-rfc/rfc8792.rb
@@ -24,20 +24,9 @@ FOLD_MSG = "NOTE: '\\' line wrapping per RFC 8792".freeze
 UNFOLD_RE = /\A.*#{FOLD_MSG.sub("\\", "(\\\\\\\\\\\\\\\\?)")}.*\n\r?\n/
 FOLD8792_PROC_RE = /\Afold(?<columns>\d*)(?<hard>hard)?(?<indent>(?<indent_type>left|smart)(?<spaces>\d*))?(?<dry>dry)?\z/
 
-def fold8792_options(proc)
-  md = FOLD8792_PROC_RE.match(proc)
-  return unless md
-
-  columns = md[:columns].to_i
-  left =
-    case md[:indent_type]
-    when "left"
-      md[:spaces].to_i
-    when "smart"
-      [:smart, md[:spaces].to_i]
-    end
-
-  [columns, left, md[:dry], md[:hard]]
+def fold8792_options(md)
+  indent_type = md[:indent_type].to_sym if md[:indent_type]
+  [md[:columns].to_i, indent_type, (md[:spaces] || 0).to_i, md[:dry], md[:hard]]
 end
 
 def unfold8792(s)
@@ -61,7 +50,7 @@ MIN_FOLD_COLUMNS = FOLD_MSG.size
 FOLD_COLUMNS = 69
 RE_IDENT = /\A[A-Za-z0-9_]\z/
 
-def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false, hard = false)
+def fold8792_1(s, columns = FOLD_COLUMNS, indent_type = nil, indent_spaces = 0, dry = false, hard = false)
   if s.index("\t")
     warn "*** HT (\"TAB\") in text to be folded. Giving up."
     return s
@@ -78,7 +67,6 @@ def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false, hard = fals
 
   lines = s.lines.map(&:chomp)
   did_fold = false
-  smart_indent_offset = left[1] if Array === left && left[0] == :smart
   smart_indent = nil
   ix = 0
   while li = lines[ix]
@@ -93,10 +81,11 @@ def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false, hard = fals
     else
       did_fold = true
       left_indent =
-        if !smart_indent_offset.nil?
-          smart_indent ||= li[/\A */].size + smart_indent_offset
-        else
-          left
+        case indent_type
+        when :left
+          indent_spaces
+        when :smart
+          smart_indent ||= li[/\A */].size + indent_spaces
         end
       min_indent = left_indent || 0
       col -= 1                  # space for "\\"
@@ -104,7 +93,7 @@ def fold8792_1(s, columns = FOLD_COLUMNS, left = false, dry = false, hard = fals
         col -= 1
       end
       if col <= min_indent
-        indent_msg = "with indent #{min_indent}" if left
+        indent_msg = "with indent #{min_indent}" if indent_type
         warn "*** Cannot RFC8792-fold1 to #{columns} cols #{indent_msg}  |#{li.inspect}|"
         smart_indent = nil
       else

--- a/lib/kramdown-rfc/rfc8792.rb
+++ b/lib/kramdown-rfc/rfc8792.rb
@@ -22,7 +22,8 @@ end
 
 FOLD_MSG = "NOTE: '\\' line wrapping per RFC 8792".freeze
 UNFOLD_RE = /\A.*#{FOLD_MSG.sub("\\", "(\\\\\\\\\\\\\\\\?)")}.*\n\r?\n/
-FOLD8792_PROC_RE = /\Afold(?<columns>\d*)(?<hard>hard)?(?:(?<indent_type>left|smart)(?<spaces>\d*))?(?<dry>dry)?\z/
+# use indent as preferred synonym over smart
+FOLD8792_PROC_RE = /\Afold(?<columns>\d*)(?<hard>hard)?(?:(?<indent_type>left|smart|indent)(?<spaces>\d*))?(?<dry>dry)?\z/
 
 def fold8792_options(md)
   indent_type = md[:indent_type].to_sym if md[:indent_type]
@@ -84,7 +85,7 @@ def fold8792_1(s, columns = FOLD_COLUMNS, indent_type = nil, indent_spaces = 0, 
         case indent_type
         when :left
           indent_spaces
-        when :smart
+        when :smart, :indent
           smart_indent ||= li[/\A */].size + indent_spaces
         end
       min_indent = left_indent || 0

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -796,7 +796,7 @@ COLORS
         when "dedent"
           result = remove_indentation(result)
         when ::FOLD8792_PROC_RE
-          fold = fold8792_options(proc)
+          fold = fold8792_options(Regexp.last_match)
           result = fix_unterminated_line(fold8792_1(trim_empty_lines_around(result), *fold)) # XXX
         when /\Alines(\d*)\.\.(\.)?(\d*)\z/
           range = Range.new($1.empty? ? nil : $1.to_i, # compensate for

--- a/lib/kramdown-rfc2629.rb
+++ b/lib/kramdown-rfc2629.rb
@@ -795,11 +795,8 @@ COLORS
         case proc
         when "dedent"
           result = remove_indentation(result)
-        when /\Afold(?<columns>\d*)(?<hard>hard)?(?<left>left(?<spaces>\d*))?(?<dry>dry)?\z/
-          md = Regexp.last_match
-          columns = md[:columns].to_i
-          left = md[:spaces].to_i if md[:left]
-          fold = [columns, left, md[:dry], md[:hard]]
+        when ::FOLD8792_PROC_RE
+          fold = fold8792_options(proc)
           result = fix_unterminated_line(fold8792_1(trim_empty_lines_around(result), *fold)) # XXX
         when /\Alines(\d*)\.\.(\.)?(\d*)\z/
           range = Range.new($1.empty? ? nil : $1.to_i, # compensate for


### PR DESCRIPTION
Adds a smart indentation variant for automated RFC 8792 folding.

The new `smartN` fold option can be used in the same position as `leftN` (they are mutually exclusive), for example:

```markdown
{::include-fold69hardsmart2dry generated.json}
```

Unlike `leftN`, which uses a fixed continuation indentation, `smartN` computes the continuation indentation from the line being folded:

```text
continuation indent = leading spaces of first folded line + N
```

This is useful for nested structured data such as JSON, where folded continuation lines should stay visually aligned with the surrounding nesting level.

Since you moved the docs to the wiki I'll leave those to you to update if this gets accepted.

---

Example input:

```json
{
  "outer": {
    "array": [
      {
        "description": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
        "nested": {
          "token": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
        }
      }
    ]
  }
}
```

With `fold69hardsmart2dry`:

```text
NOTE: '\' line wrapping per RFC 8792

{
  "outer": {
    "array": [
      {
        "description": "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\
          aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
        "nested": {
          "token": "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\
            bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb\
            bbbbbbbbbbbbbbbb"
        }
      }
    ]
  }
}
```